### PR TITLE
Phil/flowctl version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Flowctl release
 
-# Run whenever a github release is created
+# Run whenever a github release is published
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   release_binaries:
@@ -11,6 +11,8 @@ jobs:
     runs-on: ${{ matrix.config.os }} # we run a build per os
     env:
       ASSET_NAME: ${{ matrix.config.assetName }}
+      # build.rs reads this env variable and uses to set the value that's printed by flowctl --version
+      FLOWCTL_RELEASE_VERSION: ${{ github.event.release.tag_name }}
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flowctl"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "assemble",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "flowctl"
-version = "0.1.0"
+# The version here is ignored for release builds. During releases, this is instead set by the env
+# variable FLOWCTL_RELEASE_VERSION, based on the git tag.
+version = "0.1.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,19 @@
 
 **Download the binary for your OS**
 
-TODO: add links once releases are built
+- All Mac systems with MacOS 11 (Big Sur) or later, including both Intel and M1 Macs: 
+  [Download here](https://github.com/estuary/flowctl/releases/latest/download/flowctl-multiarch-macos)
+- Linux (x86-64 only), all distributions:
+  [Download here](https://github.com/estuary/flowctl/releases/latest/download/flowctl-x86_64-linux)
+
+Make the file executable, rename it, and put it somewhere on your `PATH`, for example:
+
+```console
+chmod +x ~/Downloads/flowctl-multiarch-macos
+mv ~/Downloads/flowctl-multiarch-macos /usr/local/bin/flowctl
+```
+
+Verify that it's working by running `flowctl --version`.
 
 ### Use the `flowctl` CLI:
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // If we set CARGO_PKG_VERSION this way, then it will override the default value, which is
+    // taken from the `version` in Cargo.toml.
+    if let Ok(val) = std::env::var("FLOWCTL_RELEASE_VERSION") {
+        println!("cargo:rustc-env=CARGO_PKG_VERSION={}", val);
+    }
+    println!("cargo:rerun-if-env-changed=FLOWCTL_RELEASE_VERSION");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,19 +4,19 @@ use anyhow::Context;
 use clap::Parser;
 use proto_flow::flow;
 
-mod raw;
 mod auth;
 mod catalog;
 mod config;
 mod draft;
 mod poll;
+mod raw;
 mod typescript;
 
 use poll::poll_while_queued;
 
 /// A command-line tool for working with Estuary Flow.
 #[derive(Debug, Parser)]
-#[clap(author, about)]
+#[clap(author, about, version)]
 pub struct Cli {
     /// Configuration profile to use.
     ///


### PR DESCRIPTION
Passes the value of the git tag as the version, so that `flowctl --version` will print that. I consider `--version` an essential requirement for being able to support real users of the CLI, so wanted to get this in prior to the first official release.